### PR TITLE
unice: use pointers instead of offsets for unpacking, other tweaks.

### DIFF
--- a/src/dimgutil/ice_unpack.h
+++ b/src/dimgutil/ice_unpack.h
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 2024 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2024-2025 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
- [x] Completely replace old loop with pointer version—it's faster or the same most of the time, particularly with RISC and with GCC 15 on x86-64 (clang numbers are all over the place and unusable).
- [x] Only enable fast bitplanes on 64-bit (too slow on 32-bit for every implementation tested, even with Android Go Edition on 64-bit hardware) (`SIZE_MAX` > 4b).
- [x] Force-disable tables on original bitstream.
- [x] Keep defaulting to 16-bit tables—it's slower than no tables a lot of the time, but for older compilers and clang it's *much* faster.
- [x] Revise comments, many of which are wrong.
- [x] Compiler warnings.